### PR TITLE
Add template constructor to secure_allocator

### DIFF
--- a/src/lib/alloc/secmem.h
+++ b/src/lib/alloc/secmem.h
@@ -36,6 +36,9 @@ class secure_allocator
 
       secure_allocator() BOTAN_NOEXCEPT {}
 
+      template<typename U>
+      secure_allocator(const secure_allocator<U>&) BOTAN_NOEXCEPT {}
+
       ~secure_allocator() BOTAN_NOEXCEPT {}
 
       pointer address(reference x) const BOTAN_NOEXCEPT


### PR DESCRIPTION
This is required by the Standard for an allocator. As far as I can tell, not having it breaks compilation in MSVC 2015, at least when iterator debugging is enabled. More details here: http://stackoverflow.com/q/31802806/4326278.